### PR TITLE
Include time zone in generated post metadata

### DIFF
--- a/lib/mr_poole/helper.rb
+++ b/lib/mr_poole/helper.rb
@@ -82,7 +82,7 @@ module MrPoole
     end
 
     def get_time_stamp
-      Time.now.strftime("%H:%M")
+      Time.now.strftime("%H:%M %Z")
     end
 
     def bad_path(path)


### PR DESCRIPTION
Hello!

I think it makes sense to include the time zone in the generated timestamp for a post.

I just noticed that because I hadn't been including them, my blog's RSS feed was assuming the times were in UTC, so it had some incorrect / backdated times.

An alternate approach could be to include the current time in UTC, but I _think_ this makes more sense.
